### PR TITLE
fix: wait for promises to resolve before checking truthiness

### DIFF
--- a/src/helpers/get.js
+++ b/src/helpers/get.js
@@ -53,7 +53,11 @@ const getPropertyValue = async (packageJson, property) => {
 
 const searchForLockFiles = async () => {
   for (const pkg of packagesList) {
-    const exists = pkg.lockFiles.every(async (lockFile) => await lockFileExists(lockFile))
+    const exists = (
+      await Promise.all(pkg.lockFiles.map(lockFileExists))
+    ).every(Boolean)
+
+    console.log(pkg.cmd, { exists }, pkg.lockFiles)
     if (exists) {
       return pkg.cmd
     }

--- a/src/helpers/get.js
+++ b/src/helpers/get.js
@@ -57,7 +57,6 @@ const searchForLockFiles = async () => {
       await Promise.all(pkg.lockFiles.map(lockFileExists))
     ).every(Boolean)
 
-    console.log(pkg.cmd, { exists }, pkg.lockFiles)
     if (exists) {
       return pkg.cmd
     }


### PR DESCRIPTION
I think I introduced this bug before!

The `.every` here was always returning true because a Promise instance is truthy before it's resolved. So the wrong package manager was used in some cases