### PR TITLE
Adding additional info utilities

### DIFF
--- a/src/cli/options/info.ts
+++ b/src/cli/options/info.ts
@@ -1,6 +1,5 @@
 const info = {
   describe: 'show information and versions',
-  type: 'boolean',
   conflicts: ['pin', 'unpin', 'use', 'test', 'alias']
 } as const
 

--- a/src/cli/swpm.ts
+++ b/src/cli/swpm.ts
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 
-import yargs from './swpm/config.js';
+import yargs from './swpm/config.js'
 
-import chalk from 'chalk';
-import { stripIndent } from 'common-tags';
-import { exit } from 'node:process';
-import prompts from 'prompts';
+import chalk from 'chalk'
+import { stripIndent } from 'common-tags'
+import { exit } from 'node:process'
+import prompts from 'prompts'
 
-import { autoUpdate } from '../libs/autoUpdate.js';
+import { autoUpdate } from '../libs/autoUpdate.js'
 
-import { showCommandAlias } from '../flags/alias.js';
-import { showNoPackageDetected, showPackageInformation, showPackageInformationJson, showPackageInformationSelect } from '../flags/info.js';
-import { pinPackageManager } from '../flags/pin.js';
-import { testCommand } from '../flags/test.js';
-import { unpinPackageManager } from '../flags/unpin.js';
+import { showCommandAlias } from '../flags/alias.js'
+import { showNoPackageDetected, showPackageInformation, showPackageInformationJson, showPackageInformationSelect } from '../flags/info.js'
+import { pinPackageManager } from '../flags/pin.js'
+import { testCommand } from '../flags/test.js'
+import { unpinPackageManager } from '../flags/unpin.js'
 
-import { runCommand, showCommand } from '../helpers/cmds.js';
-import { debug } from '../helpers/debug.js';
-import { commandVerification } from '../helpers/get.js';
-import { setPackageVersion } from '../helpers/set.js';
+import { runCommand, showCommand } from '../helpers/cmds.js'
+import { debug } from '../helpers/debug.js'
+import { commandVerification } from '../helpers/get.js'
+import { setPackageVersion } from '../helpers/set.js'
 
-import cmdr from '../translator/commander.js';
+import cmdr from '../translator/commander.js'
 
 if (yargs.debug) {
   debug(yargs)

--- a/src/cli/swpm.ts
+++ b/src/cli/swpm.ts
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 
-import yargs from './swpm/config.js'
+import yargs from './swpm/config.js';
 
-import prompts from 'prompts'
-import chalk from 'chalk'
-import { stripIndent } from 'common-tags'
-import { exit } from 'node:process'
+import chalk from 'chalk';
+import { stripIndent } from 'common-tags';
+import { exit } from 'node:process';
+import prompts from 'prompts';
 
-import { autoUpdate } from '../libs/autoUpdate.js'
+import { autoUpdate } from '../libs/autoUpdate.js';
 
-import { pinPackageManager } from '../flags/pin.js'
-import { unpinPackageManager } from '../flags/unpin.js'
-import { showNoPackageDetected, showPackageInformation } from '../flags/info.js'
-import { showCommandAlias } from '../flags/alias.js'
-import { testCommand } from '../flags/test.js'
+import { showCommandAlias } from '../flags/alias.js';
+import { showNoPackageDetected, showPackageInformation, showPackageInformationJson, showPackageInformationSelect } from '../flags/info.js';
+import { pinPackageManager } from '../flags/pin.js';
+import { testCommand } from '../flags/test.js';
+import { unpinPackageManager } from '../flags/unpin.js';
 
-import { showCommand, runCommand } from '../helpers/cmds.js'
-import { setPackageVersion } from '../helpers/set.js'
-import { debug } from '../helpers/debug.js'
-import { commandVerification } from '../helpers/get.js'
+import { runCommand, showCommand } from '../helpers/cmds.js';
+import { debug } from '../helpers/debug.js';
+import { commandVerification } from '../helpers/get.js';
+import { setPackageVersion } from '../helpers/set.js';
 
-import cmdr from '../translator/commander.js'
+import cmdr from '../translator/commander.js';
 
 if (yargs.debug) {
   debug(yargs)
@@ -73,7 +73,13 @@ if (yargs?.test) {
 }
 
 if (yargs?.info) {
-  await showPackageInformation(cmdr)
+  if (yargs.json) {
+    await showPackageInformationJson(cmdr)
+  } else if (typeof yargs.info === 'string') {
+    await showPackageInformationSelect(cmdr, yargs.info)
+  } else {
+    await showPackageInformation(cmdr)
+  }
 }
 
 if (yargs?.alias) {

--- a/src/flags/info.ts
+++ b/src/flags/info.ts
@@ -1,13 +1,13 @@
-import chalk from 'chalk';
-import { stripIndents } from 'common-tags';
-import { exit } from 'node:process';
+import chalk from 'chalk'
+import { stripIndents } from 'common-tags'
+import { exit } from 'node:process'
 
-import { getCommandResult } from '../helpers/cmds.js';
-import { commandVerification, get } from '../helpers/get.js';
-import { getOriginIcon } from '../helpers/icons.js';
-import { getSwpmInfo } from '../helpers/info.js';
+import { getCommandResult } from '../helpers/cmds.js'
+import { commandVerification, get } from '../helpers/get.js'
+import { getOriginIcon } from '../helpers/icons.js'
+import { getSwpmInfo } from '../helpers/info.js'
 
-import type { CommanderPackage } from '../translator/commander.types.js';
+import type { CommanderPackage } from '../translator/commander.types.js'
 
 type Info = {
   _: CommanderPackage['cmd'],
@@ -38,8 +38,8 @@ export const getPackageInformation = async ({ cmd, origin, config, volta }: Comm
   const isInstalled = !!cmd && await commandVerification(cmd)
   const packageVersion = isInstalled ? getCommandResult({ command: `${cmd} --version`, volta }) : 'not found'
 
-  const errorNoCmdFound = !cmd && 'No Package Manager or Environment Variable was found.';
-  const errorCmdNotInstalled = !isInstalled && config?.cmd && url && `Command not installed. Visit ${url} for more information.`;
+  const errorNoCmdFound = !cmd && 'No Package Manager or Environment Variable was found.'
+  const errorCmdNotInstalled = !isInstalled && config?.cmd && url && `Command not installed. Visit ${url} for more information.`
 
   const output = {
     _: cmd,
@@ -54,14 +54,14 @@ export const getPackageInformation = async ({ cmd, origin, config, volta }: Comm
       ...(config?.cmd && { [config.cmd]: packageVersion }),
     }
   }
-  return output;
+  return output
 }
 
 export const renderInfoMessage = async (info: Info, { config }: CommanderPackage) => {
-  const color = config?.color ?? chalk.reset();
-  const url = config?.url ?? '';
+  const color = config?.color ?? chalk.reset()
+  const url = config?.url ?? ''
 
-  const { _: cmd, origin, volta, versions } = info;
+  const { _: cmd, origin, volta, versions } = info
 
   let message = ''
   if (cmd) {
@@ -116,19 +116,19 @@ export const showPackageInformation = async (cmdr: CommanderPackage) => {
 export const showPackageInformationJson = async (cmdr: CommanderPackage) => {
   const output = await getPackageInformation(cmdr)
   console.log(JSON.stringify(output, null, 2))
-  exit(0);
+  exit(0)
 }
 
 
   export const showPackageInformationSelect = async (cmdr: CommanderPackage, pick: string) => {
-    const info = await getPackageInformation(cmdr);
-    const output = get(info, pick);
+    const info = await getPackageInformation(cmdr)
+    const output = get(info, pick)
     if (output) {
-      console.log(output);
-      exit (0);
+      console.log(output)
+      exit (0)
     }
-    console.log(stripIndents`Invalid value - ${pick} doesn't match any available value`);
-    await renderInfoMessage(info, cmdr);
-    exit(1);
+    console.log(stripIndents`Invalid value - ${pick} doesn't match any available value`)
+    await renderInfoMessage(info, cmdr)
+    exit(1)
   }
 

--- a/src/helpers/get.test.ts
+++ b/src/helpers/get.test.ts
@@ -1,7 +1,7 @@
-import { it, expect, describe, vi } from 'vitest'
-import { commandVerification, detectVoltaPin } from './get'
-import { CommanderPackage, PackageJson } from '../translator/commander.types'
-import { getPackageJson } from './files.js'
+import { describe, expect, it, vi } from 'vitest';
+import { CommanderPackage, PackageJson } from '../translator/commander.types';
+import { getPackageJson } from './files.js';
+import { commandVerification, detectVoltaPin, get } from './get';
 
 vi.mock('./files.ts', async () => {
   const mod = await vi.importActual<typeof import('./files.ts')>('./files.ts')
@@ -81,5 +81,23 @@ describe('detectVoltaPin', () => {
     const isVoltaInstalled = await commandVerification('volta')
     const result = await detectVoltaPin(cmdr)
     expect(isVoltaInstalled && result).toBe(false)
+  })
+})
+
+describe('get()', () => {
+  it('should return the selected properties value from a passed object', () => {
+    const obj = {
+      a: 1,
+      b: 2,
+      c: {
+        one: 'one',
+        two: 'two'
+      }
+    }
+    expect(get(obj, 'a')).toBe(1)
+    expect(get(obj, 'b')).toBe(2)
+    expect(get(obj, 'c')).toBe(obj.c)
+    expect(get(obj, 'c.one')).toBe('one')
+    expect(get(obj, 'd')).toBeUndefined()
   })
 })

--- a/src/helpers/get.test.ts
+++ b/src/helpers/get.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-import { CommanderPackage, PackageJson } from '../translator/commander.types';
-import { getPackageJson } from './files.js';
-import { commandVerification, detectVoltaPin, get } from './get';
+import { describe, expect, it, vi } from 'vitest'
+import { CommanderPackage, PackageJson } from '../translator/commander.types'
+import { getPackageJson } from './files.js'
+import { commandVerification, detectVoltaPin, get } from './get'
 
 vi.mock('./files.ts', async () => {
   const mod = await vi.importActual<typeof import('./files.ts')>('./files.ts')

--- a/src/helpers/get.ts
+++ b/src/helpers/get.ts
@@ -1,13 +1,13 @@
-import chalk from 'chalk';
-import commandExists from 'command-exists';
-import { stripIndents } from 'common-tags';
-import { env, exit } from 'node:process';
-import semver from 'semver';
-import { getPackageJson, lockFileExists } from '../helpers/files.js';
-import packagesList, { packageExists } from '../packages/list.js';
+import chalk from 'chalk'
+import commandExists from 'command-exists'
+import { stripIndents } from 'common-tags'
+import { env, exit } from 'node:process'
+import semver from 'semver'
+import { getPackageJson, lockFileExists } from '../helpers/files.js'
+import packagesList, { packageExists } from '../packages/list.js'
 
-import type { PackageManagerList } from '../packages/packages.types.js';
-import type { CommanderPackage, PackageJson } from '../translator/commander.types.js';
+import type { PackageManagerList } from '../packages/packages.types.js'
+import type { CommanderPackage, PackageJson } from '../translator/commander.types.js'
 
 const propertyExists = (packageJson: PackageJson, property: string) => {
   return (property in packageJson)
@@ -139,12 +139,12 @@ export const get = (
   const segments = path.split(/[\.\[\]]/g)
   let current: any = value
   for (const key of segments) {
-    if (current === null) return undefined;
-    if (current === undefined) return undefined;
+    if (current === null) return undefined
+    if (current === undefined) return undefined
     const dequoted = key.replace(/['"]/g, '')
     if (dequoted.trim() === '') continue
     current = current[dequoted]
   }
-  if (current === undefined) return undefined;
+  if (current === undefined) return undefined
   return current
 }

--- a/src/helpers/get.ts
+++ b/src/helpers/get.ts
@@ -1,13 +1,13 @@
-import { exit, env } from 'node:process'
-import { stripIndents } from 'common-tags'
-import chalk from 'chalk'
-import semver from 'semver'
-import commandExists from 'command-exists'
-import { getPackageJson, lockFileExists } from '../helpers/files.js'
-import packagesList, { packageExists } from '../packages/list.js'
+import chalk from 'chalk';
+import commandExists from 'command-exists';
+import { stripIndents } from 'common-tags';
+import { env, exit } from 'node:process';
+import semver from 'semver';
+import { getPackageJson, lockFileExists } from '../helpers/files.js';
+import packagesList, { packageExists } from '../packages/list.js';
 
-import type { PackageManagerList } from '../packages/packages.types.js'
-import type { CommanderPackage, PackageJson } from '../translator/commander.types.js'
+import type { PackageManagerList } from '../packages/packages.types.js';
+import type { CommanderPackage, PackageJson } from '../translator/commander.types.js';
 
 const propertyExists = (packageJson: PackageJson, property: string) => {
   return (property in packageJson)
@@ -130,4 +130,21 @@ export const commandVerification = async (cmd: PackageManagerList) => {
   } catch (error) {
     return false
   }
+}
+
+export const get = (
+  value: any,
+  path: string,
+): unknown | undefined => {
+  const segments = path.split(/[\.\[\]]/g)
+  let current: any = value
+  for (const key of segments) {
+    if (current === null) return undefined;
+    if (current === undefined) return undefined;
+    const dequoted = key.replace(/['"]/g, '')
+    if (dequoted.trim() === '') continue
+    current = current[dequoted]
+  }
+  if (current === undefined) return undefined;
+  return current
 }


### PR DESCRIPTION
Hey, this PR just adds some extra info methods that I needed personally for some CI pipelines. I've separated the data fetching logic from the rendering logic to avoid repeat work.

Hope it helps!

`swpm --info --json` will return the info spec in JSON format
```sh
> swpm --info --json`
{
  "_": "npm",
  "using": "npm",
  "error": null,
  "ready": true,
  "origin": "pinned",
  "volta": true,
  "versions": {
    "swpm": "2.6.0",
    "node": "20.9.0",
    "npm": "10.2.1"
  }
}
```

If you pass a value to info it'll pick that value back.

```sh
> swpm --info=using
npm

> swpm --info origin
pinned

> swpm --info versions.node
20.9.0

> swpm --info brokenSelection
Invalid value - brokenSelection doesn't match any available value
using:  npm 
origin: 📌 pinned 
volta:  ⚡ detected 

Versions:
swpm:   2.6.0
Node:   20.9.0
npm:    10.2.1
```

The final brokenSelection example will run `exit(1)`


No value renders the same CLI output as previous.
```sh
> swpm --info
using:  npm 
origin: 📌 pinned 
volta:  ⚡ detected 

Versions:
swpm:   2.6.0
Node:   20.9.0
npm:    10.2.1
```